### PR TITLE
Update to blobstore compatible Shock client

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -31,10 +31,11 @@
     <include name="jetty/jetty-all-7.0.0.jar"/>
     <include name="syslog4j/syslog4j-0.9.46.jar"/>
     <include name="jna/jna-3.4.0.jar"/>
-    <include name="kbase/shock/shock-client-0.0.15.jar"/>
-    <include name="apache_commons/http/httpclient-4.3.1.jar"/>
-    <include name="apache_commons/http/httpcore-4.3.jar"/>
-    <include name="apache_commons/http/httpmime-4.3.1.jar"/>
+    <include name="kbase/shock/shock-client-0.1.0.jar"/>
+    <include name="apache_commons/http/httpclient-4.5.2.jar"/>
+    <include name="apache_commons/http/httpcore-4.4.5.jar"/>
+    <include name="apache_commons/http/httpmime-4.5.8.jar"/>
+    <include name="apache_commons/commons-lang3-3.1.jar"/>
     <include name="apache_commons/commons-logging-1.1.1.jar"/>
     <include name="apache_commons/commons-net-3.3.jar"/>
     <include name="joda/joda-time-2.2.jar"/>


### PR DESCRIPTION
This client is compatible with both Shock and the new Blobstore for the
operations used in DIE.

There are no tests, but the war compiles. We'll have to test on CI I guess.