### PR TITLE
dockerize service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,14 @@ FROM kbase/kb_jre:latest as build
 RUN apt-get -y update && apt-get -y install ant git openjdk-8-jdk make
 RUN cd / && git clone https://github.com/kbase/jars
 
-ADD . /src
-RUN cd /src && ant build
-RUN find /src
+RUN cd /tmp/data_import_export && \
+  ant compile && \
+  ant buildwar
+
+#ADD . /src
+#RUN cd /src && ant build
+#RUN find /src
+
 FROM kbase/kb_jre:latest
 
 # These ARGs values are passed in via the docker build command

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ARG VCS_REF
 ARG BRANCH=develop
 
 COPY deployment/ /kb/deployment/
-COPY jettybase/ /kb/deployment/jettybase/
+COPY --from=build /tmp/data_import_export/jettybase/ /kb/deployment/jettybase/
 COPY --from=build /tmp/data_import_export/dist/KBaseDataImport.war /kb/deployment/jettybase/webapps/root.war
 
 # The BUILD_DATE value seem to bust the docker cache when the timestamp changes, move to

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM kbase/kb_jre:latest as build
 RUN apt-get -y update && apt-get -y install ant git openjdk-8-jdk make
 RUN cd / && git clone https://github.com/kbase/jars
 
+COPY . /tmp/data_import_export
+
 RUN cd /tmp/data_import_export && \
   ant compile && \
   ant buildwar

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG BRANCH=develop
 
 COPY deployment/ /kb/deployment/
 COPY jettybase/ /kb/deployment/jettybase/
-COPY --from=build /tmp/data_import_export/dist/KBaseDataImport.war /kb/deployment/jettybase/webapps/ROOT.war
+COPY --from=build /tmp/data_import_export/dist/KBaseDataImport.war /kb/deployment/jettybase/webapps/root.war
 
 # The BUILD_DATE value seem to bust the docker cache when the timestamp changes, move to
 # the end

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ RUN cd / && git clone https://github.com/kbase/jars
 COPY . /tmp/data_import_export
 
 RUN cd /tmp/data_import_export && \
-  ant compile && \
-  ant buildwar
+  ant war
 
 #ADD . /src
 #RUN cd /src && ant build

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ RUN cd / && git clone https://github.com/kbase/jars
 
 COPY . /tmp/data_import_export
 
-RUN cd /tmp/data_import_export && \
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
+
+RUN cd /tmp && ln -s /jars && \
+  cd /tmp/data_import_export && \
   ant war
 
 #ADD . /src
@@ -18,10 +21,9 @@ ARG BUILD_DATE
 ARG VCS_REF
 ARG BRANCH=develop
 
-COPY --from=build /src/deployment/ /kb/deployment/
-COPY --from=build /src/jettybase/ /kb/deployment/jettybase/
-COPY --from=build /src/dist/ /src/dist/
-COPY --from=build /jars /jars
+COPY deployment/ /kb/deployment/
+COPY jettybase/ /kb/deployment/jettybase/
+COPY --from=build /tmp/data_import_export/dist/KBaseDataImport.war /kb/deployment/jettybase/webapps/ROOT.war
 
 # The BUILD_DATE value seem to bust the docker cache when the timestamp changes, move to
 # the end

--- a/deployment/conf/.templates/http.ini.templ
+++ b/deployment/conf/.templates/http.ini.templ
@@ -1,0 +1,32 @@
+# --------------------------------------- 
+# Module: http
+--module=http
+
+### HTTP Connector Configuration
+
+## Connector host/address to bind to
+# jetty.http.host=0.0.0.0
+
+## Connector port to listen on
+jetty.http.port={{ default .Env.port "8080" }}
+
+## Connector idle timeout in milliseconds
+# jetty.http.idleTimeout=30000
+
+## Connector socket linger time in seconds (-1 to disable)
+# jetty.http.soLingerTime=-1
+
+## Number of acceptors (-1 picks default based on number of cores)
+# jetty.http.acceptors=-1
+
+## Number of selectors (-1 picks default based on number of cores)
+# jetty.http.selectors=-1
+
+## ServerSocketChannel backlog (0 picks platform default)
+# jetty.http.acceptorQueueSize=0
+
+## Thread priority delta to give to acceptor threads
+# jetty.http.acceptorPriorityDelta=0
+
+## HTTP Compliance: RFC7230, RFC2616, LEGACY
+# jetty.http.compliance=RFC7230

--- a/deployment/conf/.templates/server.ini.templ
+++ b/deployment/conf/.templates/server.ini.templ
@@ -1,0 +1,61 @@
+# --------------------------------------- 
+# Module: server
+--module=server
+
+### ThreadPool configuration
+## Minimum number of threads
+jetty.threadPool.minThreads=10
+
+## Maximum number of threads
+jetty.threadPool.maxThreads={{ default .Env.server_threads "20" }}
+
+## Thread idle timeout (in milliseconds)
+# jetty.threadPool.idleTimeout=60000
+
+### Common HTTP configuration
+## Scheme to use to build URIs for secure redirects
+# jetty.httpConfig.secureScheme=https
+
+## Port to use to build URIs for secure redirects
+# jetty.httpConfig.securePort=8443
+
+## Response content buffer size (in bytes)
+# jetty.httpConfig.outputBufferSize=32768
+
+## Max response content write length that is buffered (in bytes)
+# jetty.httpConfig.outputAggregationSize=8192
+
+## Max request headers size (in bytes)
+# jetty.httpConfig.requestHeaderSize=8192
+
+## Max response headers size (in bytes)
+# jetty.httpConfig.responseHeaderSize=8192
+
+## Whether to send the Server: header
+# jetty.httpConfig.sendServerVersion=true
+
+## Whether to send the Date: header
+# jetty.httpConfig.sendDateHeader=false
+
+## Max per-connection header cache size (in nodes)
+# jetty.httpConfig.headerCacheSize=512
+
+## Whether, for requests with content, delay dispatch until some content has arrived
+# jetty.httpConfig.delayDispatchUntilContent=true
+
+## Maximum number of error dispatches to prevent looping
+# jetty.httpConfig.maxErrorDispatches=10
+
+## Maximum time to block in total for a blocking IO operation (default -1 is to use idleTimeout on progress)
+# jetty.httpConfig.blockingTimeout=-1
+
+### Server configuration
+## Whether ctrl+c on the console gracefully stops the Jetty server
+# jetty.server.stopAtShutdown=true
+
+## Dump the state of the Jetty server, components, and webapps after startup
+# jetty.server.dumpAfterStart=false
+
+## Dump the state of the Jetty server, components, and webapps before shutdown
+# jetty.server.dumpBeforeStop=false
+

--- a/deployment/conf/.templates/start_server.sh.templ
+++ b/deployment/conf/.templates/start_server.sh.templ
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+
+JAVA_OPTS="-Djava.awt.headless=true -server \
+               -Xms{{ default .Env.min_memory "1000" }}m -Xmx{{ default .Env.max_memory "3000" }}m \
+               -XX:+UseG1GC"
+
+# This script assumes that the docker base image includes a runnable JETTY environment
+# that provides $JETTY_HOME. Currently the base image is built on library/jetty:jre8
+java -DSTOP.PORT=8079 -DSTOP.KEY=foo -Djetty.home=$JETTY_HOME -jar $JETTY_HOME/start.jar


### PR DESCRIPTION
Please do not merge yet.

Run service from dockerize so we no longer need the monolithic image (which doesn't support TLSv1.2).